### PR TITLE
LTSEPADD-9: Modify Curator App to 7zip exported content

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -11,3 +11,4 @@ services:
     volumes:
       - ./logs:/home/appuser/epadd-curator-app/logs
       - ./keys:/home/appuser/epadd-curator-app/keys
+      - ./zip:/home/appuser/epadd-curator-app/zip

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -11,4 +11,5 @@ services:
     volumes:
       - ./logs:/home/appuser/epadd-curator-app/logs
       - ./keys:/home/appuser/epadd-curator-app/keys
-      - ./zip:/home/appuser/epadd-curator-app/zip
+      - ./zip_exports:/home/appuser/epadd-curator-app/zip_exports
+      - ./download_exports:/home/appuser/epadd-curator-app/download_exports

--- a/env-example.txt
+++ b/env-example.txt
@@ -30,3 +30,5 @@ NEXTCLOUD_AWS_SECRET_KEY=
 TEST_EXPORT_FILE_PATH=/home/appuser/epadd-curator-app/test_export
 TEST_PREFIX=test/
 TEST_SIDECAR_FILE_PATH=/home/appuser/epadd-curator-app/resources/drsConfig.txt
+ZIPPED_EXPORT_PATH=/home/appuser/epadd-curator-app/zip_exports/
+DOWNLOAD_EXPORT_PATH=/home/appuser/epadd-curator-app/download_exports/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ pytest==6.2.2
 botocore==1.27.55
 boto3==1.24.55
 PyJWT==2.4.0
+py7zr=0.20.2
 cryptography==37.0.2
 jcs==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pytest==6.2.2
 botocore==1.27.55
 boto3==1.24.55
 PyJWT==2.4.0
-py7zr=0.20.2
+py7zr==0.20.2
 cryptography==37.0.2
 jcs==0.2.0

--- a/scripts/monitor_epadd_exports.py
+++ b/scripts/monitor_epadd_exports.py
@@ -252,7 +252,7 @@ def retrieve_export(zip_path, manifest_parent_prefix):
                 os.makedirs(os.path.dirname(local_file))
             else if obj.key[-1] == '/':
                 continue
-            bucket.download_file(obj.key, local_file)
+            epadd_bucket.download_file(obj.key, local_file)
 
         zip_local_dir = zip_path + "/" + manifest_parent_prefix
         return zip_local_dir

--- a/scripts/unit_tests.py
+++ b/scripts/unit_tests.py
@@ -60,8 +60,8 @@ class TestZipUnitCases(unittest.TestCase):
 
     def setUpClass():
         # create download and zip dirs if they don't exist
-        download_export_path = "./download_exports/"
-        zip_export_path = "./zip_exports/"
+        download_export_path = "../download_exports/"
+        zip_export_path = "../zip_exports/"
         if (not os.path.exists(download_export_path)):
             os.makedirs(download_export_path, exist_ok = True)
         if (not os.path.exists(zip_export_path)):
@@ -69,7 +69,7 @@ class TestZipUnitCases(unittest.TestCase):
 
     def test_retrieve_export_1(self): #test download from S3
         manifest_parent_prefix = "integration_test/"
-        download_export_path = "./download_exports"
+        download_export_path = "../download_exports"
         monitor_epadd_exports.connect_to_bucket()
         zip_local_dir = monitor_epadd_exports.retrieve_export(download_export_path, manifest_parent_prefix)
         file_exists = os.path.exists(zip_local_dir)
@@ -81,15 +81,15 @@ class TestZipUnitCases(unittest.TestCase):
         self.assertEqual(True, dir_has_items)
 
     def test_retrieve_export_2(self): #test zip of export
-        zip_export_path = "./zip_exports/"
-        download_export_path = "./download_exports/"
+        zip_export_path = "../zip_exports/"
+        download_export_path = "../download_exports/"
         manifest_parent_prefix = "integration_test/"
         file_path = monitor_epadd_exports.zip_export(zip_export_path, download_export_path, manifest_parent_prefix)
         file_exists = os.path.exists(file_path)
         self.assertEqual(True, file_exists)
     
     def test_retrieve_export_3(self): #test upload of export
-        zip_path = "./zip_exports/integration_test.7z"
+        zip_path = "../zip_exports/integration_test.7z"
         manifest_parent_prefix = "integration_test/"
         success = monitor_epadd_exports.upload_zip_export(zip_path, manifest_parent_prefix)
         self.assertEqual(True, success)

--- a/scripts/unit_tests.py
+++ b/scripts/unit_tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-import unittest, os
+import unittest, os, os.path
 import unittest.mock as mock
 os.environ['JWT_EXPIRATION'] = '99999999'
 import monitor_epadd_exports
@@ -54,6 +54,36 @@ class TestMonitorUnitCases(unittest.TestCase):
         filelist = monitor_epadd_exports.collect_exports()
         correctlist = ["test/manifest-sha256.txt/msdos.txt", "test/manifest-md5.txt/index.html"]
         self.assertEqual(filelist, correctlist)
+
+
+class TestMonitorIntegrationCases(unittest.TestCase):
+
+       def test_retrieve_export(self):
+        manifest_parent_prefix = "integration_test/"
+        zip_path = "./"
+        zip_local_dir = monitor_epadd_exports.retrieve_export()
+        file_exists = os.path.exists(zip_local_dir)
+        self.assertEqual(True, file_exists)
+        self.assertEqual(True, file_exists)
+
+    def test_zip_export(self):
+        zip_path = "./"
+        manifest_parent_prefix = "integration_test/"
+        file_path = monitor_epadd_exports.zip_export(zip_path, manifest_parent_prefix)
+        file_exists = os.path.exists(file_path)
+        dir_has_items = False
+        if os.path.exists(file_path) and not os.path.isfile(file_path):
+            if os.listdir(path):
+                dir_has_items = True
+        self.assertEqual(True, file_exists)
+        self.assertEqual(True, dir_has_items)
+    
+    def test_upload_zip_export(self):
+        zip_path = "./integration_test/integration_test.7z"
+        manifest_parent_prefix = "integration_test/"
+        success = upload_zip_export(zip_path, manifest_parent_prefix)
+        self.assertEqual(True, success)
+
 
 
 if __name__ == '__main__':

--- a/scripts/unit_tests.py
+++ b/scripts/unit_tests.py
@@ -2,7 +2,8 @@
 
 import unittest, os, os.path
 import unittest.mock as mock
-os.environ['JWT_EXPIRATION'] = '99999999'
+from dotenv import load_dotenv
+load_dotenv()
 import monitor_epadd_exports
 
 class MockS3Resource:
@@ -50,38 +51,47 @@ class TestMonitorUnitCases(unittest.TestCase):
     @mock.patch("monitor_epadd_exports.s3_resource", MockS3Resource() )
     @mock.patch("monitor_epadd_exports.epadd_bucket_name", "test_bucket" )
     @mock.patch("monitor_epadd_exports.epadd_bucket", MockEpaddBucket() )
-    def test_skip(self):
+    def test_file_skip(self):
         filelist = monitor_epadd_exports.collect_exports()
         correctlist = ["test/manifest-sha256.txt/msdos.txt", "test/manifest-md5.txt/index.html"]
         self.assertEqual(filelist, correctlist)
 
+class TestZipUnitCases(unittest.TestCase):
 
-class TestMonitorIntegrationCases(unittest.TestCase):
+    def setUpClass():
+        # create download and zip dirs if they don't exist
+        download_export_path = "./download_exports/"
+        zip_export_path = "./zip_exports/"
+        if (not os.path.exists(download_export_path)):
+            os.makedirs(download_export_path, exist_ok = True)
+        if (not os.path.exists(zip_export_path)):
+            os.makedirs(zip_export_path, exist_ok = True)
 
-       def test_retrieve_export(self):
+    def test_retrieve_export_1(self): #test download from S3
         manifest_parent_prefix = "integration_test/"
-        zip_path = "./"
-        zip_local_dir = monitor_epadd_exports.retrieve_export()
+        download_export_path = "./download_exports"
+        monitor_epadd_exports.connect_to_bucket()
+        zip_local_dir = monitor_epadd_exports.retrieve_export(download_export_path, manifest_parent_prefix)
         file_exists = os.path.exists(zip_local_dir)
-        self.assertEqual(True, file_exists)
-        self.assertEqual(True, file_exists)
-
-    def test_zip_export(self):
-        zip_path = "./"
-        manifest_parent_prefix = "integration_test/"
-        file_path = monitor_epadd_exports.zip_export(zip_path, manifest_parent_prefix)
-        file_exists = os.path.exists(file_path)
         dir_has_items = False
-        if os.path.exists(file_path) and not os.path.isfile(file_path):
-            if os.listdir(path):
+        if file_exists and not os.path.isfile(zip_local_dir):
+            if os.listdir(zip_local_dir):
                 dir_has_items = True
         self.assertEqual(True, file_exists)
         self.assertEqual(True, dir_has_items)
-    
-    def test_upload_zip_export(self):
-        zip_path = "./integration_test/integration_test.7z"
+
+    def test_retrieve_export_2(self): #test zip of export
+        zip_export_path = "./zip_exports/"
+        download_export_path = "./download_exports/"
         manifest_parent_prefix = "integration_test/"
-        success = upload_zip_export(zip_path, manifest_parent_prefix)
+        file_path = monitor_epadd_exports.zip_export(zip_export_path, download_export_path, manifest_parent_prefix)
+        file_exists = os.path.exists(file_path)
+        self.assertEqual(True, file_exists)
+    
+    def test_retrieve_export_3(self): #test upload of export
+        zip_path = "./zip_exports/integration_test.7z"
+        manifest_parent_prefix = "integration_test/"
+        success = monitor_epadd_exports.upload_zip_export(zip_path, manifest_parent_prefix)
         self.assertEqual(True, success)
 
 


### PR DESCRIPTION
**Modify Curator App to 7zip exported content**
* * *

**Ticket Link**:  https://jira.huit.harvard.edu/browse/LTSEPADD-9

# What does this Pull Request do?
Extract the DRS Config file and delete once data is extracted, prior to deposit.
7-Zip the directory contents for deposit.

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

unit testing:

0. get dev config info for your .env file and then populate the .env file
2.  cd to the scripts dir
3. `python3 -m unittest unit_tests.py `
4.  all unit tests should pass.  you should see a downloaded export in ./download_exports and a zip file in ./zip_exports
`aws s3 ls s3://epadd-export-dev/integration_test/integration_test.7z --profile YOUR_AWS_PROFILE  ` to see the uploaded zip in the s3 bucket
5. to reset, `aws s3 rm s3://epadd-export-dev/integration_test/integration_test.7z --profile YOUR_AWS_PROFILE  `
cd to the base of the project and do a `rm -fr download_exports zip_exports`

integration testing

1. `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
2. http://localhost:10586/testExport  to start the test export


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? y
- integration tests?

# Interested parties
Tag (@ mention) interested parties
@awoods 