### PR TITLE
Monitor and testing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,23 @@ curl http://ltsds-cloud-dev-1.lib.harvard.edu:10586/testExport?osn={yourTestOSN}
 ```
 curl http://ltsds-cloud-dev-1.lib.harvard.edu:10586/testExport
 ```
+
+## Running Performance Tests in QA
+
+Performance tests write their own drsConfig.txt and will ignore any drsConfig.txt files that are provided with the directory.  The provided drsConfig.txt generates a random OSN of the form osn_<timestamp> and sends emails to DTS@HU.onmicrosoft.com
+
+## Prerequisites
+
+- NextCloud account that allows access to the directory int-test-data-store (This looks like epadd-int-test-data-store in the NC directory)
+
+
+### 1: Upload desired directory to epadd-int-test-data-store (see Prerequisites) or utilize the existing data
+
+### 2: From a browser, make a call to:
+```
+http://ltsds-cloud-dev-1.lib.harvard.edu:10586/runTest/<name of directory>
+```
+### 3: Verify that the batch report comes through 
+This can be done in two ways:
+1. Receiving an email to DTS@HU.onmicrosoft.com if you are part of that group
+2. Manually checking the dropbox for a load report.  In QA, the ePADD dropbox is located on ldi3 under epaddqa_secure in the drs QA dropboxes directories.  Load reports will show up under the batch name (osn_<timestamp>-batch)

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -94,7 +94,7 @@ def call_dims_ingest(manifest_object_key):
     try:
         shutil.rmtree(download_dir)
     except:
-        logging.error("Error while deleting zipped export: " + zip_file)
+        logging.error("Error while deleting download directory: " + download_dir)
         
     # calculate iat and exp values
     current_datetime = datetime.now()

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -269,15 +269,27 @@ def retrieve_export(download_path, manifest_parent_prefix):
     try:
         logging.debug("Downloading {}".format(manifest_parent_prefix))
         for obj in epadd_bucket.objects.filter(Prefix=manifest_parent_prefix):
-            logging.debug("Moving {}".format(obj.key))
-            local_file = os.path.join(download_path, obj.key)
+            
+            #Remove dropbox
+            keywithoutdropboxprefix = obj.key[len(epadd_dropbox_prefix_name)+1:]
+            logging.debug("without dropbox: {}".format(keywithoutdropboxprefix))
+            userbucket = keywithoutdropboxprefix[0:keywithoutdropboxprefix.find("/")]
+            logging.debug("user bucket: {}".format(userbucket))
+            key = keywithoutdropboxprefix[len(userbucket)+1:]
+            logging.debug("Moving {}".format(key))
+
+            local_file = os.path.join(download_path, key)
             if not os.path.exists(os.path.dirname(local_file)):
                 os.makedirs(os.path.dirname(local_file))
             elif (obj.key[-1] == "/"):
                 continue
             epadd_bucket.download_file(obj.key, local_file)
 
-        download_local_dir = os.path.join(download_path, manifest_parent_prefix)
+        pathwithoutdropboxprefix = manifest_parent_prefix[len(epadd_dropbox_prefix_name)+1:]
+        logging.debug("without dropbox: {}".format(pathwithoutdropboxprefix))
+        userbucket = pathwithoutdropboxprefix[0:pathwithoutdropboxprefix.find("/")]    
+        download_dir = pathwithoutdropboxprefix[len(userbucket)+1:]
+        download_local_dir = os.path.join(download_path, download_dir)
         return download_local_dir
     except Exception as err:
         logging.error(traceback.format_exc())

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -55,7 +55,7 @@ def call_dims_ingest(manifest_object_key):
     """
     logging.debug("Preparing to call DIMS")
     # get parent prefix of manifest file
-    manifest_parent_prefix = os.path.basename(os.path.dirname(manifest_object_key))
+    manifest_parent_prefix = os.path.dirname(manifest_object_key)
 
     try:
         with open(jwt_private_key_path) as jwt_private_key_file:

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -295,7 +295,7 @@ def retrieve_export(download_path, manifest_parent_prefix):
         pathwithoutdropboxprefix = manifest_parent_prefix[len(epadd_dropbox_prefix_name):]
         pathwithoutdropboxprefix = pathwithoutdropboxprefix.lstrip("/")
         logging.debug("without dropbox: {}".format(pathwithoutdropboxprefix))
-        if "?" in pathwithoutdropboxprefix:
+        if "/" in pathwithoutdropboxprefix:
             userbucket = pathwithoutdropboxprefix[0:pathwithoutdropboxprefix.find("/")]    
             download_dir = pathwithoutdropboxprefix[len(userbucket):]
             download_dir = download_dir.lstrip("/")

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -292,10 +292,12 @@ def retrieve_export(download_path, manifest_parent_prefix):
                 continue
             epadd_bucket.download_file(obj.key, local_file)
 
-        pathwithoutdropboxprefix = manifest_parent_prefix[len(epadd_dropbox_prefix_name)+1:]
+        pathwithoutdropboxprefix = manifest_parent_prefix[len(epadd_dropbox_prefix_name):]
+        pathwithoutdropboxprefix = pathwithoutdropboxprefix.lstrip("/")
         logging.debug("without dropbox: {}".format(pathwithoutdropboxprefix))
         userbucket = pathwithoutdropboxprefix[0:pathwithoutdropboxprefix.find("/")]    
-        download_dir = pathwithoutdropboxprefix[len(userbucket)+1:]
+        download_dir = pathwithoutdropboxprefix[len(userbucket):]
+        download_dir = download_dir.lstrip("/")
         download_local_dir = os.path.join(download_path, download_dir)
         return download_local_dir
     except Exception as err:

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -295,9 +295,12 @@ def retrieve_export(download_path, manifest_parent_prefix):
         pathwithoutdropboxprefix = manifest_parent_prefix[len(epadd_dropbox_prefix_name):]
         pathwithoutdropboxprefix = pathwithoutdropboxprefix.lstrip("/")
         logging.debug("without dropbox: {}".format(pathwithoutdropboxprefix))
-        userbucket = pathwithoutdropboxprefix[0:pathwithoutdropboxprefix.find("/")]    
-        download_dir = pathwithoutdropboxprefix[len(userbucket):]
-        download_dir = download_dir.lstrip("/")
+        if "?" in pathwithoutdropboxprefix:
+            userbucket = pathwithoutdropboxprefix[0:pathwithoutdropboxprefix.find("/")]    
+            download_dir = pathwithoutdropboxprefix[len(userbucket):]
+            download_dir = download_dir.lstrip("/")
+        else:
+            download_dir = pathwithoutdropboxprefix
         download_local_dir = os.path.join(download_path, download_dir)
         return download_local_dir
     except Exception as err:

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -276,11 +276,13 @@ def retrieve_export(download_path, manifest_parent_prefix):
         for obj in epadd_bucket.objects.filter(Prefix=manifest_parent_prefix):
             
             #Remove dropbox
-            keywithoutdropboxprefix = obj.key[len(epadd_dropbox_prefix_name)+1:]
+            keywithoutdropboxprefix = obj.key[len(epadd_dropbox_prefix_name):]
+            keywithoutdropboxprefix = keywithoutdropboxprefix.lstrip("/")
             logging.debug("without dropbox: {}".format(keywithoutdropboxprefix))
             userbucket = keywithoutdropboxprefix[0:keywithoutdropboxprefix.find("/")]
             logging.debug("user bucket: {}".format(userbucket))
-            key = keywithoutdropboxprefix[len(userbucket)+1:]
+            key = keywithoutdropboxprefix[len(userbucket):]
+            key = key.lstrip("/")
             logging.debug("Moving {}".format(key))
 
             local_file = os.path.join(download_path, key)

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -279,10 +279,13 @@ def retrieve_export(download_path, manifest_parent_prefix):
             keywithoutdropboxprefix = obj.key[len(epadd_dropbox_prefix_name):]
             keywithoutdropboxprefix = keywithoutdropboxprefix.lstrip("/")
             logging.debug("without dropbox: {}".format(keywithoutdropboxprefix))
-            userbucket = keywithoutdropboxprefix[0:keywithoutdropboxprefix.find("/")]
-            logging.debug("user bucket: {}".format(userbucket))
-            key = keywithoutdropboxprefix[len(userbucket):]
-            key = key.lstrip("/")
+            if "/" in pathwithoutdropboxprefix:
+                userbucket = keywithoutdropboxprefix[0:keywithoutdropboxprefix.find("/")]
+                logging.debug("user bucket: {}".format(userbucket))
+                key = keywithoutdropboxprefix[len(userbucket):]
+                key = key.lstrip("/")
+            else:
+                key = keywithoutdropboxprefix
             logging.debug("Moving {}".format(key))
 
             local_file = os.path.join(download_path, key)

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -38,6 +38,7 @@ jwt_private_key_path = os.getenv('JWT_PRIVATE_KEY_PATH')
 jwt_expiration = int(os.getenv('JWT_EXPIRATION'))
 zip_path = os.getenv('ZIPPED_EXPORT_PATH')
 download_export_path = os.getenv('DOWNLOAD_EXPORT_PATH')
+environment = os.getenv("ENV")
 
 logging.debug("Executing monitor_epadd_exports.py")
 
@@ -279,13 +280,14 @@ def retrieve_export(download_path, manifest_parent_prefix):
             keywithoutdropboxprefix = obj.key[len(epadd_dropbox_prefix_name):]
             keywithoutdropboxprefix = keywithoutdropboxprefix.lstrip("/")
             logging.debug("without dropbox: {}".format(keywithoutdropboxprefix))
-            if "/" in keywithoutdropboxprefix:
+            if environment == "development":
+                key = obj.key
+            else:
                 userbucket = keywithoutdropboxprefix[0:keywithoutdropboxprefix.find("/")]
                 logging.debug("user bucket: {}".format(userbucket))
                 key = keywithoutdropboxprefix[len(userbucket):]
                 key = key.lstrip("/")
-            else:
-                key = keywithoutdropboxprefix
+
             logging.debug("Moving {}".format(key))
 
             local_file = os.path.join(download_path, key)
@@ -298,12 +300,13 @@ def retrieve_export(download_path, manifest_parent_prefix):
         pathwithoutdropboxprefix = manifest_parent_prefix[len(epadd_dropbox_prefix_name):]
         pathwithoutdropboxprefix = pathwithoutdropboxprefix.lstrip("/")
         logging.debug("without dropbox: {}".format(pathwithoutdropboxprefix))
-        if "/" in pathwithoutdropboxprefix:
+        if environment == "development":
+            download_dir = manifest_parent_prefix
+        else:
             userbucket = pathwithoutdropboxprefix[0:pathwithoutdropboxprefix.find("/")]    
             download_dir = pathwithoutdropboxprefix[len(userbucket):]
             download_dir = download_dir.lstrip("/")
-        else:
-            download_dir = pathwithoutdropboxprefix
+
         download_local_dir = os.path.join(download_path, download_dir)
         return download_local_dir
     except Exception as err:

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -279,7 +279,7 @@ def retrieve_export(download_path, manifest_parent_prefix):
             keywithoutdropboxprefix = obj.key[len(epadd_dropbox_prefix_name):]
             keywithoutdropboxprefix = keywithoutdropboxprefix.lstrip("/")
             logging.debug("without dropbox: {}".format(keywithoutdropboxprefix))
-            if "/" in pathwithoutdropboxprefix:
+            if "/" in keywithoutdropboxprefix:
                 userbucket = keywithoutdropboxprefix[0:keywithoutdropboxprefix.find("/")]
                 logging.debug("user bucket: {}".format(userbucket))
                 key = keywithoutdropboxprefix[len(userbucket):]

--- a/app/run_tests/__init__.py
+++ b/app/run_tests/__init__.py
@@ -34,7 +34,7 @@ epadd_source_name = os.getenv('EPADD_SOURCE_NAME')
 #The prefix that is being monitored for the tests
 epadd_int_test_prefix_name = os.getenv('EPADD_TEST_PREFIX_NAME', "")
 
-logging.debug("Executing test_export.py")
+logging.debug("Executing run_tests.py")
 
 # s3 connection
 boto_session = None
@@ -56,6 +56,9 @@ def connect_to_buckets():
 
     # Then use the session to get the resource
     s3_resource = boto_session.resource('s3')
+    
+    epadd_bucket = s3_resource.Bucket(epadd_bucket_name)
+    logging.debug("Connected to S3 bucket: " + epadd_bucket_name)
                                                                                 
                                                                                 
 

--- a/app/run_tests/__init__.py
+++ b/app/run_tests/__init__.py
@@ -32,7 +32,7 @@ epadd_source_type = os.getenv("EPADD_SOURCE_TYPE")
 #The prefix or directory of where the data is stored prior to testing
 epadd_source_name = os.getenv('EPADD_SOURCE_NAME')
 #The prefix that is being monitored for the tests
-epadd_int_test_prefix_name = os.getenv('EPADD_INT_TEST_PREFIX_NAME', "")
+epadd_int_test_prefix_name = os.getenv('EPADD_TEST_PREFIX_NAME', "")
 
 logging.debug("Executing test_export.py")
 
@@ -56,10 +56,8 @@ def connect_to_buckets():
 
     # Then use the session to get the resource
     s3_resource = boto_session.resource('s3')
-
-    epadd_bucket = s3_resource.Bucket(epadd_bucket_name)
-    logging.debug("Connected to S3 bucket: " + epadd_bucket_name)
-
+                                                                                
+                                                                                
 
 def copy_from_source_to_test(dirName = None):
     if dirName is None:

--- a/env-example.txt
+++ b/env-example.txt
@@ -26,6 +26,8 @@ JWT_EXPIRATION=1800
 
 # Nextcloud
 EPADD_BUCKET_NAME=epadd-export-dev
+#blank for dev
+EPADD_DROPBOX_PREFIX_NAME=dropboxes
 NEXTCLOUD_AWS_ACCESS_KEY=
 NEXTCLOUD_AWS_SECRET_KEY=
 
@@ -35,12 +37,8 @@ NEXTCLOUD_AWS_SECRET_KEY=
 #QA: S3 (prefix)
 EPADD_SOURCE_TYPE=FS
 #prefix or directory that contains the stored data for testing
-#Dev: /home/appuser/epadd-curator-app/test_files
-#QA: epadd-int-test-data-store
 EPADD_SOURCE_NAME=/home/appuser/epadd-curator-app/test_files
 #Prefix being used for integration tests 
-#Dev: Leave blank
-#QA: dropboxes
 EPADD_TEST_PREFIX_NAME=
 
 # BatchBuilder Admin Category


### PR DESCRIPTION
**Fixes to ensure working in QA**
* * *

**Ticket Link**: https://jira.huit.harvard.edu/browse/LTSEPADD-25

# What does this Pull Request do?
Modifications to work with the QA directory structure.

# How should this be tested?
**Dev**
Verification changes remained in dev:

This is on dev currently. You can test one run through by calling:
http://ltsds-cloud-dev-1.lib.harvard.edu:10586/runTest/devTestPrefix

This will add data to the S3 bucket. You can see the data by getting the credentials from LPE for epadd dev and calling:
`aws s3 ls s3://epadd-export-dev/`
You will see devTestPrefix in the bucket.

The EASProjectEmail export will be picked up by a cron job that runs every 5 minutes. It will be moved into the dev dropbox with an osn_<timestamp> name. This can viewed in by logging into the  `ltsds-cloud-dev-1.lib.harvard.edu` server and then cd-ing to `/drs2dev/drsfs/dropbox/epadddev_secure/incoming/`
Once the batch has processed, it will be renamed to `osn_<timestamp>-batch`.
Under the `osn_<timestamp>-batch` directory, a `LOADREPORT_osn_<timestamp>-batch.txt` file will appear once it made it into the DRS
The whole process of the batch to make it into the DRS will take no longer than 5 minutes.

**QA**
This has to be merged in order to be deployed to QA.  Testing was done by manually modifying the QA environment with the updated code.  Once deployed, you can verify testing by:

Call: http://ltsds-cloud-qa-1.lib.harvard.edu:10586/runTest/ePADD-eml-export

This will add data to the S3 bucket. You can see the data by getting the credentials from LPE for epadd qa and calling:
`aws s3 ls s3://epadd-export-qa/`
You will see ePADD-eml-export in the bucket.

The ePADD-eml-export export will be picked up by a cron job that runs every 5 minutes. It will be moved into the dev dropbox with an osn_<timestamp> name. This can viewed in by logging into the  `ldi-3.lib.harvard.edu` server and then cd-ing to `/drs2qa/drsfs/dropbox/epaddqa_secure/incoming/`
Once the batch has processed, it will be renamed to `osn_<timestamp>-batch`.
Under the `osn_<timestamp>-batch` directory, a `LOADREPORT_osn_<timestamp>-batch.txt` file will appear once it made it into the DRS
The whole process of the batch to make it into the DRS will take no longer than 5 minutes.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? no

# Interested parties
Tag (@ mention) interested parties
