### PR TITLE
Add SSL and fix tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,11 @@ RUN chown appuser:appuser -R /home/appuser && \
     chown appuser:appuser -R /logs
 
 USER appuser
+# Append SAN section to openssl.cnf and generate a new self-signed certificate and key
+RUN mkdir -p /home/appuser/ssl/certs && \
+    cp /etc/ssl/openssl.cnf /home/appuser/ssl/openssl.cnf && \
+    printf "[SAN]\nsubjectAltName=DNS:*.hul.harvard.edu,DNS:*.lts.harvard.edu" >> /home/appuser/ssl/openssl.cnf && \
+    openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=US/ST=Massachusetts/L=Cambridge/O=Library Technology Services/CN=*.lib.harvard.edu" -extensions SAN -reqexts SAN -config /home/appuser/ssl/openssl.cnf -keyout /home/appuser/ssl/certs/server.key -out /home/appuser/ssl/certs/server.crt
 
 RUN npm install && \
     python3 -m pip install -U pip && \

--- a/app.js
+++ b/app.js
@@ -4,7 +4,18 @@ const express = require('express');
 const app = express();
 const port = 8443
 
-app.listen(port, () => {
+var fs = require('fs'),
+    http = require('http'),
+    https = require('https');
+
+const options = {
+   key: fs.readFileSync('/home/appuser/ssl/certs/server.key', 'utf8'),
+   cert: fs.readFileSync('/home/appuser/ssl/certs/server.crt', 'utf8')
+};
+
+var server = https.createServer(options, app);
+
+server.listen(port, () => {
    console.log('Server running on port: ${port}');
 });
 

--- a/scripts/unit_tests.py
+++ b/scripts/unit_tests.py
@@ -191,7 +191,7 @@ class TestConstructPayload(unittest.TestCase):
     @mock.patch("monitor_exports.epadd_bucket_name", "test_bucket" )
     @mock.patch("monitor_exports.epadd_bucket", MockEpaddBucket() )
     def test_construct_payload(self):
-        payload = monitor_epadd_exports.construct_payload_body("/home/appuser/epadd-curator-app/resources/EmlExample")
+        payload = monitor_epadd_exports.construct_payload_body("/home/appuser/epadd-curator-app/resources/EmlExample", "")
         self.assertTrue(payload, "Payload returned was empty")
           
 class TestZipEpaddExports(unittest.TestCase):
@@ -242,6 +242,7 @@ class TestCopySingleExportFS(unittest.TestCase):
     @mock.patch("run_tests.epadd_source_type", "FS" )
     @mock.patch("run_tests.epadd_source_name", "/home/appuser/epadd-curator-app/resources" )
     @mock.patch("run_tests.epadd_test_bucket_name", "test_bucket" )
+    @mock.patch("run_tests.epadd_source_bucket", MockEpaddPerformanceTestingSourceBucket())
     @mock.patch("run_tests.epadd_test_bucket", MockEpaddPerformanceTestingDestinationBucket() )
     def test_copy_one(self):
         run_tests.copy_from_source_to_test('EmlExample')
@@ -250,7 +251,7 @@ class TestCopySingleExportFS(unittest.TestCase):
     
 
     def test_construct_payload(self):
-        payload = monitor_epadd_exports.construct_payload_body("/home/appuser/epadd-curator-app/resources/EmlExample")
+        payload = monitor_epadd_exports.construct_payload_body("/home/appuser/epadd-curator-app/resources/EmlExample", "")
         self.assertTrue(payload, "Payload returned was empty")
         
 class TestZipEpaddExports(unittest.TestCase):

--- a/scripts/unit_tests.py
+++ b/scripts/unit_tests.py
@@ -138,7 +138,7 @@ class TestZipUnitCases(unittest.TestCase):
         download_export_path = "/home/appuser/epadd-curator-app/download_exports"
         zip_export_path = "/home/appuser/epadd-curator-app/zip_exports"
         zip_file = os.path.join(zip_export_path, "integration_test.7z")
-        loading_file = os.path.join(download_export_path, "integration_testLOADING")
+        loading_file = os.path.join(download_export_path, "integration_test/LOADING")
         os.remove(zip_file)
         os.remove(loading_file)
         download_path = os.path.join(download_export_path, "integration_test")
@@ -150,7 +150,7 @@ class TestZipUnitCases(unittest.TestCase):
         download_export_path = "/home/appuser/epadd-curator-app/download_exports"
         zip_export_path = "/home/appuser/epadd-curator-app/zip_exports"
         zip_file = os.path.join(zip_export_path, "integration_test.7z")
-        loading_file = os.path.join(download_export_path, "integration_testLOADING")
+        loading_file = os.path.join(download_export_path, "integration_test/LOADING")
         os.remove(zip_file)
         os.remove(loading_file)
         download_path = os.path.join(download_export_path, "integration_test")


### PR DESCRIPTION
**Add SSL and fix tests**
* * *

**Ticket Link**: [LTSEPADD-72](https://jira.huit.harvard.edu/browse/LTSEPADD-72)

# What does this Pull Request do?
This PR add SSL certificates to the epadd-curator-app. It also has some fixes for unit tests.

# How should this be tested?

1. Build and run curator app with `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
2. Run `docker exec -it epadd-curator-app python3 -m unittest scripts/unit_tests.py`
3. Confirm all tests pass
4. Go to `https://localhost:10586/healthcheck`
5. Confirm healthcheck works

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? yes
- integration tests? n/a

# Interested parties
@ives1227 
