### PR TITLE
Update to for 7zip to start at package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,10 @@ pdftmp/*pdf
 #pickle file
 pickle
 
+# VIM files
+*.swp
+*~
+
 **/node_modules
 
 pdfstorerdaemon.pid

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -323,7 +323,7 @@ def zip_export(zip_path, directory_to_zip):
         zip_filename = os.path.join(zip_path, manifest_parent_prefix + ".7z")
         logging.debug("Zipping directory {} into {} ".format(directory_to_zip, zip_filename))
         with py7zr.SevenZipFile(zip_filename, 'w') as archive:
-            archive.writeall(directory_to_zip)
+            archive.writeall(directory_to_zip, manifest_parent_prefix)
         return zip_filename
     except Exception as err:
         logging.error(traceback.format_exc())


### PR DESCRIPTION
Update to for 7zip to start at package name, not absolute path

Also removes duplicate unit test: TestZipEpaddExports

Resolves: https://jira.huit.harvard.edu/browse/LTSEPADD-82

# What does this Pull Request do?
This update changes the created 7zip files to contain files rooted at the <object_name> instead of the absolute path to the object dir being zipped (i.e. now <obj_name> instead of /home/appuser/epadd-curator-app/download_exports/<obj_name>)

# How should this be tested?
- Pull down this PR
- [Start the container](https://github.com/harvard-lts/epadd-curator-app#4-start)
- [SSH into the container](https://github.com/harvard-lts/epadd-curator-app#5-ssh-into-container-optional)
- [Run unit tests](https://github.com/harvard-lts/epadd-curator-app#3-run-the-tests)


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? Yes
- integration tests? No :(

# Interested parties
@ives1227 / @jessjass 
