### PR TITLE
Fix zip hidden file download error

### DIFF
--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -293,7 +293,9 @@ def retrieve_export(download_path, manifest_parent_prefix):
             local_file = os.path.join(download_path, key)
             if not os.path.exists(os.path.dirname(local_file)):
                 os.makedirs(os.path.dirname(local_file))
+                logging.debug("Created dir {}".format(os.path.dirname(local_file)))
             elif (obj.key[-1] == "/"):
+                logging.debug("Not creating dir for {}".format(obj.key))
                 continue
             epadd_bucket.download_file(obj.key, local_file)
 

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -291,13 +291,14 @@ def retrieve_export(download_path, manifest_parent_prefix):
             logging.debug("Moving {}".format(key))
 
             local_file = os.path.join(download_path, key)
-            if not os.path.exists(os.path.dirname(local_file)):
+            if (obj.key[-1] == "/"):
+                if not os.path.exists(local_file):
+                    os.makedirs(local_file)
+                    logging.debug("Created dir {}".format(local_file))
+            elif not os.path.exists(os.path.dirname(local_file)):
                 os.makedirs(os.path.dirname(local_file))
                 logging.debug("Created dir for file {}".format(local_file))
-            elif (obj.key[-1] == "/"):
-                logging.debug("Not creating dir for {}".format(obj.key))
-                continue
-            epadd_bucket.download_file(obj.key, local_file)
+                epadd_bucket.download_file(obj.key, local_file)
 
         pathwithoutdropboxprefix = manifest_parent_prefix[len(epadd_dropbox_prefix_name):]
         pathwithoutdropboxprefix = pathwithoutdropboxprefix.lstrip("/")

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -291,11 +291,15 @@ def retrieve_export(download_path, manifest_parent_prefix):
             logging.debug("Moving {}".format(key))
 
             local_file = os.path.join(download_path, key)
+            # If the obj.key is a path, and the corresponding download dir doesn't exist
+            # then create the dir and don't attempt to download a file
             if (obj.key[-1] == "/"):
                 if not os.path.exists(local_file):
                     os.makedirs(local_file)
                     logging.debug("Created dir {}".format(local_file))
                 continue
+            # Else if obj.key is a file, create the dir if the download dir doesn't already
+            # exist. Then attempt to download the file.
             elif not os.path.exists(os.path.dirname(local_file)):
                 os.makedirs(os.path.dirname(local_file))
                 logging.debug("Created dir for file {}".format(local_file))

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -295,10 +295,11 @@ def retrieve_export(download_path, manifest_parent_prefix):
                 if not os.path.exists(local_file):
                     os.makedirs(local_file)
                     logging.debug("Created dir {}".format(local_file))
+                continue
             elif not os.path.exists(os.path.dirname(local_file)):
                 os.makedirs(os.path.dirname(local_file))
                 logging.debug("Created dir for file {}".format(local_file))
-                epadd_bucket.download_file(obj.key, local_file)
+            epadd_bucket.download_file(obj.key, local_file)
 
         pathwithoutdropboxprefix = manifest_parent_prefix[len(epadd_dropbox_prefix_name):]
         pathwithoutdropboxprefix = pathwithoutdropboxprefix.lstrip("/")

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -293,7 +293,7 @@ def retrieve_export(download_path, manifest_parent_prefix):
             local_file = os.path.join(download_path, key)
             if not os.path.exists(os.path.dirname(local_file)):
                 os.makedirs(os.path.dirname(local_file))
-                logging.debug("Created dir {}".format(os.path.dirname(local_file)))
+                logging.debug("Created dir for file {}".format(local_file))
             elif (obj.key[-1] == "/"):
                 logging.debug("Not creating dir for {}".format(obj.key))
                 continue

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -292,7 +292,8 @@ def retrieve_export(download_path, manifest_parent_prefix):
 
             local_file = os.path.join(download_path, key)
             # If the obj.key is a path, and the corresponding download dir doesn't exist
-            # then create the dir and don't attempt to download a file
+            # then create the dir and don't attempt to download a file.
+            # Hidden files also have obj.key ending in '/' and will be excluded from download.
             if (obj.key[-1] == "/"):
                 if not os.path.exists(local_file):
                     os.makedirs(local_file)


### PR DESCRIPTION
**Fix zip hidden file download error**
* * *

**Ticket Link**: [LTSEPADD-86](https://jira.huit.harvard.edu/browse/LTSEPADD-86)

# What does this Pull Request do?
When files are synced to s3 via NextCloud, empty hidden files are also uploaded with the export dirs. Those files were causing a NotADirectoryError when attempting download. This PR fixes the download of those files.

# How should this be tested?

Tested on dev

Build and run container locally with `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
Exec into container
Run test with `python3 -m unittest scripts/unit_tests.py `

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? yes
- integration tests? yes

# Interested parties
@awoods @ives1227 
