### PR TITLE
Remove extra whitespace and null bytes from drsConfig parsing

### DIFF
--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -168,6 +168,10 @@ def construct_payload_body(download_dir, full_prefix):
     metadata_dict = {}
     with open(drsconfig) as drs_config_file:
         for line in drs_config_file:
+            #Remove whitespace
+            line = line.strip()
+            #Remove unicode
+            line = line.encode("ascii", "ignore").decode()
             if len(line) > 0:
                 split_val = line.split('=')
                 metadata_dict[split_val[0]] = split_val[1]

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -213,7 +213,7 @@ def construct_payload_body(download_dir, full_prefix):
 def strip_unicode_and_whitespace(line):
     #Remove whitespace
     line = line.strip()
-    #Remove hex bytes
+    #Remove null bytes
     line = line.replace("\x00",'') 
     #Remove unicode
     line = line.encode("ascii", "ignore").decode()

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -168,10 +168,8 @@ def construct_payload_body(download_dir, full_prefix):
     metadata_dict = {}
     with open(drsconfig) as drs_config_file:
         for line in drs_config_file:
-            #Remove whitespace
-            line = line.strip()
-            #Remove unicode
-            line = line.encode("ascii", "ignore").decode()
+            #Remove unicode and whitespace
+            line = strip_unicode_and_whitespace(line)
             if len(line) > 0:
                 split_val = line.split('=')
                 metadata_dict[split_val[0]] = split_val[1]
@@ -212,6 +210,15 @@ def construct_payload_body(download_dir, full_prefix):
 
     return payload_data
 
+def strip_unicode_and_whitespace(line):
+    #Remove whitespace
+    line = line.strip()
+    #Remove hex bytes
+    line = line.replace("\x00",'') 
+    #Remove unicode
+    line = line.encode("ascii", "ignore").decode()
+    return line
+            
 
 def key_exists(key):
     """

--- a/scripts/unit_tests.py
+++ b/scripts/unit_tests.py
@@ -187,6 +187,11 @@ class TestConstructPayload(unittest.TestCase):
     def test_construct_payload(self):
         payload = monitor_epadd_exports.construct_payload_body("/home/appuser/epadd-curator-app/resources/EmlExample", "")
         self.assertTrue(payload, "Payload returned was empty")
+        
+    def test_strip_unicode_tabs_and_blank_lines(self):
+        mystring="LOWUSE\x00\x00\x00\x00\x00\x00"
+        retval = monitor_epadd_exports.strip_unicode_and_whitespace(mystring)
+        self.assertEqual(retval,"LOWUSE")
           
 
 # class TestCopySingleExportS3(unittest.TestCase):

--- a/scripts/unit_tests.py
+++ b/scripts/unit_tests.py
@@ -192,6 +192,12 @@ class TestConstructPayload(unittest.TestCase):
         mystring="LOWUSE\x00\x00\x00\x00\x00\x00"
         retval = monitor_epadd_exports.strip_unicode_and_whitespace(mystring)
         self.assertEqual(retval,"LOWUSE")
+        mystring2="key=val         "
+        retval2 = monitor_epadd_exports.strip_unicode_and_whitespace(mystring2)
+        self.assertEqual(retval2,"key=val")
+        mystring3="VALUE\u0000"
+        retval3 = monitor_epadd_exports.strip_unicode_and_whitespace(mystring3)
+        self.assertEqual(retval3,"VALUE")
           
 
 # class TestCopySingleExportS3(unittest.TestCase):


### PR DESCRIPTION
**Removes the whitespace and null bytes when parsing the drsConfig.txt**
* * *

**Ticket Link**: https://jira.huit.harvard.edu/browse/LTSEPADD-98

# How should this be tested?
Run unit tests following the readme: https://github.com/harvard-lts/epadd-curator-app#running-tests

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? yes
- integration tests? no

