### PR TITLE
Checks the user dropbox for something before trying to process

### DIFF
--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -271,7 +271,7 @@ def collect_exports():
             user_dropbox_path = user_dropbox.get('Prefix')
             #This gets the list of the exported names under the user 'dropbox'
             export_names = s3_resource.meta.client.list_objects_v2(Bucket=epadd_bucket_name, Prefix=user_dropbox_path, Delimiter="/")
-            for export_dir in export_names.get('CommonPrefixes'):
+            for "CommonPrefixes" in export_names and export_dir in export_names.get('CommonPrefixes'):
                 epadd_bucket_objects.append(export_dir.get('Prefix'))
     #Format is just <export name>/<data>
     #Example ePADD-eml-export/<data>

--- a/app/monitor_exports/__init__.py
+++ b/app/monitor_exports/__init__.py
@@ -271,8 +271,9 @@ def collect_exports():
             user_dropbox_path = user_dropbox.get('Prefix')
             #This gets the list of the exported names under the user 'dropbox'
             export_names = s3_resource.meta.client.list_objects_v2(Bucket=epadd_bucket_name, Prefix=user_dropbox_path, Delimiter="/")
-            for "CommonPrefixes" in export_names and export_dir in export_names.get('CommonPrefixes'):
-                epadd_bucket_objects.append(export_dir.get('Prefix'))
+            if "CommonPrefixes" in export_names:
+                for export_dir in export_names.get('CommonPrefixes'):
+                    epadd_bucket_objects.append(export_dir.get('Prefix'))
     #Format is just <export name>/<data>
     #Example ePADD-eml-export/<data>
     else:   


### PR DESCRIPTION
**Checks for 'CommonPrefixes' in the user dropbox which indicates there are more prefixes (directories) below the user dropbox*
* * *

**Ticket Link**: https://jira.huit.harvard.edu/browse/LTSEPADD-100

# How should this be tested?

Already tested in QA by manually updating the code in the container.  The way to test:
1. Empty out your NextCloud dropbox (verify using the CLI that it is empty: `aws s3 ls s3://epadd-export-qa/dropboxes/awoods-qa/ --profile <your QA profile name>`
2.  Deploy to QA (merge this into main) 
3. If the integration tests pass the deployment, the code works (int tests were failing because of this bug)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

