### PR TITLE
Adding marker file when processing

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -18,3 +18,4 @@ services:
       - ./resources:/home/appuser/epadd-curator-app/resources
       - ./app:/home/appuser/epadd-curator-app/app
       - ./scripts/unit_tests.py:/home/appuser/epadd-curator-app/scripts/unit_tests.py
+      - ./markers:/home/appuser/epadd-curator-app/markers

--- a/env-example.txt
+++ b/env-example.txt
@@ -55,3 +55,5 @@ DATA_PATH=/home/appuser/epadd-curator-app/resources
 # Set to True if DIMS should not be called, False otherwise
 TESTING=False
 
+#Marker file
+MONITOR_MARKER=/home/appuser/epadd-curator-app/markers/MONITOR_RUNNING


### PR DESCRIPTION
**Adds a marker file to prevent multiple processing events to run at the same time**
* * *

**Ticket Link**: https://jira.huit.harvard.edu/browse/LTSEPADD-101

Visual check in the /docker/hdc3a/config/epadd-curator-app/markers directory on the server.  A marker will appear every 5 minutes briefly and stay for the duration of the processing.  I've verified this on dev.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? no

